### PR TITLE
Add Stream Support: Accept-Ranges: bytes for some file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,13 @@ Replace config file located `~/config/imageprocessor/security.config`
   </services>
 </security>
 ```
+
+## Streaming for audio and video files
+In case that you need to stream audio and/or video files you will need to the following application setting to you web.config
+```xml
+<configuration>
+  <appSettings>
+      <add key="Umbraco.S3.AllowedStreamFiles" value="mp3,mp4" />
+  </appSettings>
+</configuration>
+```

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/FileSystemVirtualPathProviderFile.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/FileSystemVirtualPathProviderFile.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Configuration;
 using System.IO;
+using System.Linq;
+using System.Web;
 using System.Web.Hosting;
 
 namespace Umbraco.Storage.S3
@@ -7,18 +10,32 @@ namespace Umbraco.Storage.S3
     internal class FileSystemVirtualPathProviderFile : VirtualFile
     {
         private readonly Func<Stream> _stream;
+        private readonly string[] _extensionArray;
 
         public FileSystemVirtualPathProviderFile(string virtualPath, Func<Stream> stream) : base(virtualPath)
         {
             if (stream == null)
                 throw new ArgumentNullException("stream");
             _stream = stream;
+
+            string validExtensions = ConfigurationSettings.AppSettings["Umbraco.S3.Stream.Extensions"];
+            _extensionArray = validExtensions?.Split(',');
         }
 
         public override Stream Open()
         {
+            if (HttpContext.Current != null)
+            {
+                var path = HttpContext.Current.Request.FilePath;
+                if (_extensionArray.Any(x => path.Contains(x)))
+                {
+                    HttpContext.Current.Response.AppendHeader("Accept-Ranges", "bytes");
+                }
+            }
+
             return _stream();
         }
+
 
         public override bool IsDirectory
         {
@@ -26,3 +43,4 @@ namespace Umbraco.Storage.S3
         }
     }
 }
+

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/FileSystemVirtualPathProviderFile.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/FileSystemVirtualPathProviderFile.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Storage.S3
                 throw new ArgumentNullException("stream");
             _stream = stream;
 
-            string validExtensions = ConfigurationSettings.AppSettings["Umbraco.S3.Stream.Extensions"];
+            string validExtensions = ConfigurationSettings.AppSettings["Umbraco.S3.AllowedStreamFiles"];
             _extensionArray = validExtensions?.Split(',');
         }
 
@@ -27,7 +27,7 @@ namespace Umbraco.Storage.S3
             if (HttpContext.Current != null)
             {
                 var path = HttpContext.Current.Request.FilePath;
-                if (_extensionArray.Any(x => path.Contains(x)))
+                if (_extensionArray != null && _extensionArray.Any(x => path.Contains(x)))
                 {
                     HttpContext.Current.Response.AppendHeader("Accept-Ranges", "bytes");
                 }


### PR DESCRIPTION
Hey
I have added the extensions to stream by web.config.

<add key="Umbraco.S3.Stream.Extensions" value="mp3,mp4"/>

