### PR TITLE
GetDirectories issue when hostname not provided

### DIFF
--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketExtensionsTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketExtensionsTests.cs
@@ -7,6 +7,15 @@ namespace Umbraco.Storage.S3.Tests
     public class BucketExtensionsTests
     {
         [Test]
+        public void BucketHostnameNull()
+        {
+            //Act
+            var actual = BucketExtensions.ParseBucketHostName(null);
+            //Assert
+            Assert.AreEqual("/", actual);
+        }
+
+        [Test]
         public void BucketHostnameTrailingSlash()
         {
             //Arrange

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
@@ -81,7 +81,7 @@ namespace Umbraco.Storage.S3
                 return BucketPrefix;
 
             //Remove Bucket Hostname
-            if (path.StartsWith(BucketHostName, StringComparison.InvariantCultureIgnoreCase))
+            if (!path.Equals("/") && path.StartsWith(BucketHostName, StringComparison.InvariantCultureIgnoreCase))
                 path = path.Substring(BucketHostName.Length);
 
             path = path.Replace("\\", Delimiter);


### PR DESCRIPTION
Hey, this fixes an issue we came across where `GetDirectories` was returning no results because the path becomes the same default as the bucket hostname.

We haven't provided a hostname as per the documentation, since we are using virtual path provider.
https://github.com/ElijahGlover/Umbraco-S3-Provider#virtual-path-provider-recommended-for-umbraco--735

You can see in BucketFileSystem > GetDirectories on line 117, the path gets set to `"/"`, and also in BucketExtensions when parsing the bucket hostname, if none is provided, you will also get `"/"`.

This causes a problem with `ResolveBucketPath` as line 85 will now kick in, which means that line 88 doesn't match anymore and the code continues to run and you end up with `media//` as your Prefix for the `GetDirectories` request, which doesn't return any results.

I've added a check to line 84 and added some more tests to confirm what should happen.

This particular issue came about when we noticed that our media folders were not incrementing correctly in Umbraco, and tracked that down to this code that Umbraco calls to retrieve the list of directories from the file system provider (i.e. this package):
https://github.com/umbraco/Umbraco-CMS/blob/c09cd95eb6a9faa587f81afb79d543652c3f48bd/src/Umbraco.Core/IO/MediaFileSystem.cs#L186