### PR TITLE
Configuration of S3 Canned ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Update ~/Config/FileSystemProviders.config
       <add key="bucketKeyPrefix" value="media" />
       <!-- AWS Region Endpoint (us-east-1/us-west-1/ap-southeast-2) Important to get right otherwise all API requests will return a 30x response -->
       <add key="region" value="us-east-1" />
-	  <!-- S3 Canned ACL - Sets permissions for uploaded files. Defaults to public-read if the key is omitted or the value is blank. -->
+	  <!-- S3 Canned ACL - Sets permissions for uploaded files. Defaults to public-read if the key is omitted or the value is invalid. -->
       <add key="cannedACL" value="public-read" />
     </Parameters>
   </Provider>
@@ -58,7 +58,7 @@ Before you enable this option you might want to read how Virtual Path Providers 
 - Create/modify applications `~/global.asax`
 ```c#
 using Umbraco.Storage.S3;
-      
+
 public class Global : UmbracoApplication
 {
    protected override void OnApplicationStarting(object sender, EventArgs e)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Update ~/Config/FileSystemProviders.config
       <add key="bucketKeyPrefix" value="media" />
       <!-- AWS Region Endpoint (us-east-1/us-west-1/ap-southeast-2) Important to get right otherwise all API requests will return a 30x response -->
       <add key="region" value="us-east-1" />
+	  <!-- S3 Canned ACL - Sets permissions for uploaded files. Defaults to public-read if the key is omitted or the value is blank. -->
+      <add key="cannedACL" value="public-read" />
     </Parameters>
   </Provider>
 </FileSystemProviders>

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/AclExtensionsTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/AclExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using Umbraco.Storage.S3.Extensions;
+using Amazon.S3;
+
+namespace Umbraco.Storage.S3.Tests
+{
+    [TestFixture]
+    class AclExtensionsTests
+    {
+        [Test]
+        public void CannedACLNull()
+        {
+            var actual = AclExtensions.ParseCannedAcl(null);
+            Assert.AreEqual(S3CannedACL.PublicRead, actual);
+        }
+
+        [Test]
+        public void CannedACLEmpty()
+        {
+            var actual = AclExtensions.ParseCannedAcl("");
+            Assert.AreEqual(S3CannedACL.PublicRead, actual);
+        }
+
+        [Test]
+        public void CannedACLInvalid()
+        {
+            var actual = AclExtensions.ParseCannedAcl("invalid-value");
+            Assert.AreEqual(S3CannedACL.PublicRead, actual);
+        }
+
+        [Test]
+        public void CannedACLValid()
+        {
+            var publicRead = AclExtensions.ParseCannedAcl("public-read");
+            Assert.AreEqual(S3CannedACL.PublicRead, publicRead);
+
+            var noACL = AclExtensions.ParseCannedAcl("NoACL");
+            Assert.AreEqual(S3CannedACL.NoACL, noACL);
+
+            var publicReadWrite = AclExtensions.ParseCannedAcl("public-read-write");
+            Assert.AreEqual(S3CannedACL.PublicReadWrite, publicReadWrite);
+        }
+
+    }
+}

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
@@ -25,11 +25,12 @@ namespace Umbraco.Storage.S3.Tests
             string bucketName,
             string bucketHostName,
             string bucketKeyPrefix,
-            string region)
+            string region,
+            string cannedACL = null)
         {
             var logHelperMock = new Mock<ILogHelper>();
             var mimeTypeHelper = new Mock<IMimeTypeResolver>();
-            return new BucketFileSystem(bucketName, bucketHostName, bucketKeyPrefix, region)
+            return new BucketFileSystem(bucketName, bucketHostName, bucketKeyPrefix, region, cannedACL)
             {
                 ClientFactory = () => mock.Object,
                 LogHelper = logHelperMock.Object,
@@ -132,7 +133,7 @@ namespace Umbraco.Storage.S3.Tests
         public void AddFileWithBucketPrefix()
         {
             //Arrange
-            var steam = new MemoryStream();
+            var stream = new MemoryStream();
             var clientMock = new Mock<IAmazonS3>();
             clientMock.Setup(p => p.PutObject(It.Is<PutObjectRequest>(req => req.Key == "media/1001/media.jpg")))
                       .Returns(new PutObjectResponse());
@@ -140,7 +141,25 @@ namespace Umbraco.Storage.S3.Tests
             var provider = CreateProvider(clientMock);
 
             //Act
-            provider.AddFile("/media/1001/media.jpg", steam);
+            provider.AddFile("/media/1001/media.jpg", stream);
+
+            //Assert
+            clientMock.VerifyAll();
+        }
+
+        [Test]
+        public void AddFileWithValidCannedACL()
+        {
+            //Arrange
+            var stream = new MemoryStream();
+            var clientMock = new Mock<IAmazonS3>();
+            clientMock.Setup(p => p.PutObject(It.Is<PutObjectRequest>(req => req.Key == "media/1001/media.jpg")))
+                      .Returns(new PutObjectResponse());
+
+            var provider = CreateProviderWithParams(clientMock, "test", null, "media", string.Empty, "private");
+
+            //Act
+            provider.AddFile("/media/1001/media.jpg", stream);
 
             //Assert
             clientMock.VerifyAll();

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/Umbraco.Storage.S3.Tests.csproj
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/Umbraco.Storage.S3.Tests.csproj
@@ -74,6 +74,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BucketExtensionsTests.cs" />
+    <Compile Include="AclExtensionsTests.cs" />
     <Compile Include="BucketFileSystemAbsoluteTests.cs" />
     <Compile Include="BucketFileSystemRelativeTests.cs" />
     <Compile Include="FileSystemCacheProviderTests.cs" />

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Storage.S3
         protected readonly string BucketName;
         protected readonly string BucketHostName;
         protected readonly string BucketPrefix;
+        protected readonly S3CannedACL ACL;
         protected const string Delimiter = "/";
         protected const int BatchSize = 1000;
 
@@ -24,8 +25,10 @@ namespace Umbraco.Storage.S3
             string bucketName,
             string bucketHostName,
             string bucketKeyPrefix,
-            string region)
+            string region,
+            string cannedACL)
         {
+            
             if (string.IsNullOrEmpty(bucketName))
                 throw new ArgumentNullException("bucketName");
 
@@ -33,11 +36,19 @@ namespace Umbraco.Storage.S3
             BucketHostName = BucketExtensions.ParseBucketHostName(bucketHostName);
             BucketPrefix = BucketExtensions.ParseBucketPrefix(bucketKeyPrefix);
 
+            ACL = AclExtensions.ParseCannedAcl(cannedACL);
+
             var regionEndpoint = RegionEndpoint.GetBySystemName(region);
             ClientFactory = () => new AmazonS3Client(regionEndpoint);
             LogHelper = new LogHelperWrapper();
             MimeTypeResolver = new DefaultMimeTypeResolver();
         }
+
+        public BucketFileSystem(
+            string bucketName,
+            string bucketHostName,
+            string bucketKeyPrefix,
+            string region): this(bucketName, bucketHostName, bucketKeyPrefix, region, null) { }
 
         public Func<IAmazonS3> ClientFactory { get; set; }
 
@@ -186,12 +197,11 @@ namespace Umbraco.Storage.S3
             using (var memoryStream = new MemoryStream())
             {
                 stream.CopyTo(memoryStream);
-
                 var request = new PutObjectRequest
                 {
                     BucketName = BucketName,
                     Key = ResolveBucketPath(path),
-                    CannedACL = S3CannedACL.PublicRead,
+                    CannedACL = ACL,
                     ContentType = MimeTypeResolver.Resolve(path),
                     InputStream = memoryStream
                 };
@@ -334,6 +344,6 @@ namespace Umbraco.Storage.S3
             //It Is Not Possible To Get Object Created Date - Bucket Versioning Required
             //Return Last Modified Date Instead
             return GetLastModified(path);
-        }
+        }    
     }
 }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Storage.S3
             string region,
             string cannedACL)
         {
-            
+
             if (string.IsNullOrEmpty(bucketName))
                 throw new ArgumentNullException("bucketName");
 
@@ -344,6 +344,6 @@ namespace Umbraco.Storage.S3
             //It Is Not Possible To Get Object Created Date - Bucket Versioning Required
             //Return Last Modified Date Instead
             return GetLastModified(path);
-        }    
+        }
     }
 }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/CachedBucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/CachedBucketFileSystem.cs
@@ -13,8 +13,9 @@ namespace Umbraco.Storage.S3
             string bucketKeyPrefix,
             string region,
             string cachePath,
-            string timeToLive)
-            : base(bucketName, bucketHostName, bucketKeyPrefix, region)
+            string timeToLive,
+            string cannedACL)
+            : base(bucketName, bucketHostName, bucketKeyPrefix, region, cannedACL)
         {
             int timeToLiveValue;
             if (!int.TryParse(timeToLive, out timeToLiveValue))
@@ -23,6 +24,15 @@ namespace Umbraco.Storage.S3
             var timeToLiveTimeSpan = TimeSpan.FromSeconds(timeToLiveValue);
             CacheProvider = new FileSystemCacheProvider(timeToLiveTimeSpan, cachePath);
         }
+
+        public CachedBucketFileSystem(
+            string bucketName,
+            string bucketHostName,
+            string bucketKeyPrefix,
+            string region,
+            string cachePath,
+            string timeToLive)
+            : this(bucketName, bucketHostName, bucketKeyPrefix, region, cachePath, timeToLive, null) { }
 
         public ICacheProvider CacheProvider { get; set; }
 

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/Extensions/AclExtensions.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/Extensions/AclExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Amazon.S3;
+using System.Linq;
+
+namespace Umbraco.Storage.S3.Extensions
+{
+    public static class AclExtensions
+    {
+        private static string[] ValidAcls = new string[]
+        {
+            "private",
+            "public-read",
+            "public-read-write",
+            "aws-exec-read",
+            "authenticated-read",
+            "bucket-owner-read",
+            "bucket-owner-full-control",
+            "NoACL",
+        };
+
+        public static S3CannedACL ParseCannedAcl(string aclParam)
+        {
+            if (string.IsNullOrEmpty(aclParam))
+            {
+                return S3CannedACL.PublicRead;
+            }
+
+            return ValidAcls.Contains(aclParam)
+                ? S3CannedACL.FindValue(aclParam)
+                : S3CannedACL.PublicRead;
+        }
+    }
+}

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/Umbraco.Storage.S3.csproj
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/Umbraco.Storage.S3.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\BucketExtensions.cs" />
+    <Compile Include="Extensions\AclExtensions.cs" />
     <Compile Include="BucketFileSystem.cs" />
     <Compile Include="CachedBucketFileSystem.cs" />
     <Compile Include="Services\ICacheProvider.cs" />


### PR DESCRIPTION
Hello! 
This PR adds functionality to manage permissions of uploaded files. This functionality has previously been referenced in Issue https://github.com/ElijahGlover/Umbraco-S3-Provider/issues/21

Users can now specify an optional `cannedACL` param in `FileSystemProviders.config` which sets the cannedACL of uploaded files accordingly. The default fallback for files is still `public-read`. 

The PR also fixes a typo in `BucketFileSystemAbsoluteTests.cs`