### PR TITLE
Make the ETag property available

### DIFF
--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
@@ -354,5 +354,17 @@ namespace Umbraco.Storage.S3
             var response = Execute(client => client.GetObjectMetadata(request));
             return response.ContentLength;
         }
+
+        public virtual string GetETag(string path)
+        {
+            var request = new GetObjectMetadataRequest
+            {
+                BucketName = Config.BucketName,
+                Key = ResolveBucketPath(path)
+            };
+
+            var response = Execute(client => client.GetObjectMetadata(request));
+            return response.ETag;
+        }
     }
 }


### PR DESCRIPTION
Allow the S3 ETag property to be discoverable for use in custom HTTP module.