### PR TITLE
Update for Umbraco 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Umbraco S3 Provider
 
-[Amazon Web Services S3](http://aws.amazon.com/s3/) IFileSystem provider for Umbraco 7. Used to offload static files (ie media/templates/stylesheets) to the cloud! You don't have to be hosting your code in EC2 to get the benefits like handling large media libraries, freeing up disk space and removing static files from your deployment process.
+[Amazon Web Services S3](http://aws.amazon.com/s3/) IFileSystem provider for Umbraco 8. Used to offload media to the cloud! You don't have to be hosting your code in EC2 to get the benefits like handling large media libraries, freeing up disk space and removing static files from your deployment process.
 
 Most of the code floating around the internet are slight modifications to code contained in this repository. If you're not 100% happy with it, submit a pull request or open dialog with the rest of the community. It's heavily unit tested against the official AWS S3 .Net API bindings.
 
@@ -8,40 +8,32 @@ Most of the code floating around the internet are slight modifications to code c
 
 ## Installation & Configuration
 
-Due to implementation changes in Umbraco > 7.3.5, you must use Virtual Path Provider along with ImageProcessor changes to generate thumbnails in the backoffice.
-
 Install via NuGet.org - Packaged upon every comment thanks to the guys at [AppVeyor](http://www.appveyor.com/)
 ```powershell
 Install-Package Umbraco.Storage.S3
 ```
 
-Update ~/Config/FileSystemProviders.config
+Add the following keys to `~/Web.config`
 ```xml
 <?xml version="1.0"?>
-<FileSystemProviders>
-  <Provider alias="media" type="Umbraco.Storage.S3.BucketFileSystem, Umbraco.Storage.S3">
-    <Parameters>
-      <!-- S3 Bucket Name -->
-      <add key="bucketName" value="{Your Unique Bucket Name}" />
-      <!-- S3 Bucket Hostname - Used for storage in umbraco's database (Should be blank when using Virtual File Provider) -->
-      <add key="bucketHostName" value="" />
-      <!-- S3 Object Key Prefix - What should we prefix keys with? -->
-      <add key="bucketKeyPrefix" value="media" />
-      <!-- AWS Region Endpoint (us-east-1/us-west-1/ap-southeast-2) Important to get right otherwise all API requests will return a 30x response -->
-      <add key="region" value="us-east-1" />
-	  <!-- S3 Canned ACL - Sets permissions for uploaded files. Defaults to public-read if the key is omitted or the value is invalid. -->
-      <add key="cannedACL" value="public-read" />
-      <!-- S3 ServerSide Encryption Method - Enable encryption on files/folders. Defaults to None if the key is omitted or the value is invalid. -->
-      <add key="serverSideEncryptionMethod" value="AES256" />
-    </Parameters>
-  </Provider>
-</FileSystemProviders>
+<configuration>
+  <appSettings>
+    <add key="BucketFileSystem:Region" value="" />
+    <add key="BucketFileSystem:BucketPrefix" value="media" />
+    <add key="BucketFileSystem:BucketName" value="" />
+    <add key="BucketFileSystem:BucketHostname" value="" />
+    <add key="BucketFileSystem:DisableVirtualPathProvider" value="false" />
+  </appSettings>
+</configuration>
 ```
+`Region`, `BucketPrefix`, and `BucketName` are always required.
+If `DisableVirtualPathProvider` is set to `true`, you must include `BucketHostname`. However, if `DisableVirtualPathProvider` is set to `false` then `BucketHostname` doesn't have any effect.
+`DisableVirtualPathProvider` defaults to `false`.
+
 Ok so where are the [IAM access keys?](http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html) Depending on how you host your project they already exist if deploying inside an EC2 instance via environment variables specified during deployment and creation of infrastructure.
 It's also a good idea to use [AWS best security practices](http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html). Like not using your root access account, use short lived access keys and don't EVER commit them to source control.
 
-If you aren't using EC2/ElasticBeanstalk to access generated temporary keys, you can put them within your application (AppSettings in web.config)
-
+If you aren't using EC2/ElasticBeanstalk to access generated temporary keys, you can put them into `~/Web.config`
 ```xml
 <?xml version="1.0"?>
 <configuration>
@@ -52,25 +44,7 @@ If you aren't using EC2/ElasticBeanstalk to access generated temporary keys, you
 </configuration>
 ```
 
-## Virtual Path Provider (Recommended for Umbraco > 7.3.5)
-If your wanting to serve files transparently from your domain or serve templates/stylesheets directly from S3 it's possible by using a custom [Virtual Path Provider](https://msdn.microsoft.com/en-us/library/system.web.hosting.virtualpathprovider%28v=vs.110%29.aspx) included.
-Before you enable this option you might want to read how Virtual Path Providers affect performance/caching as it differs from IIS's [unmanaged handler](http://www.paraesthesia.com/archive/2011/05/02/when-staticfilehandler-is-not-staticfilehandler.aspx/).
-
-- Set bucketHostName value to empty string inside `~/Config/FileSystemProviders.config` *(This will prevent the S3 hostname from being prepended when uploaded from within Umbraco)*
-- Create/modify applications `~/global.asax`
-```c#
-using Umbraco.Storage.S3;
-
-public class Global : UmbracoApplication
-{
-   protected override void OnApplicationStarting(object sender, EventArgs e)
-   {
-      FileSystemVirtualPathProvider.ConfigureMedia();
-      base.OnApplicationStarting(sender, e);
-   }
-}
-```
-- Add static file handler to serve all files from the media directory
+If you have left `DisableVirtualPathProvider` as the default, then you'll need to add the following to `~/Web.config`
 ```xml
 <?xml version="1.0"?>
 <configuration>
@@ -84,9 +58,7 @@ public class Global : UmbracoApplication
   </location>
 </configuration>
 ```
-
-For **Umbraco v7.5+ you must add the the StaticFileHandler** to the new Web.config inside the `Media` folder instead of the root one or the VPP will not work!
-
+You also need to add the following to `~/Media/Web.config`
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
@@ -100,8 +72,16 @@ For **Umbraco v7.5+ you must add the the StaticFileHandler** to the new Web.conf
 </configuration>
 ```
 
-## Using ImageProcessor (Recommended for Umbraco > 7.3.5)
-Support for remote files has been added to ImageProcessor in version > `2.3.2`. You'll also want to ensure that you are using Virtual Path Provider as ImageProcessor only hijacks requests when parameters are present in the querystring (like width, height, etc)
+## Should I use the Virtual Path Provider?
+Using a custom [Virtual Path Provider](https://msdn.microsoft.com/en-us/library/system.web.hosting.virtualpathprovider%28v=vs.110%29.aspx) (the default configuration) means your files are routed transparently through your domain (e.g. `https://example.com/media`). Anyone visiting your site won't be able to tell your files are stored on S3.
+
+Turning the VPP functionality off will store the full S3 URL for each media item, and this will be visible to anyone visiting your site.
+
+Before making a decision either way you might want to read how Virtual Path Providers affect performance/caching, as it differs from IIS's [unmanaged handler](http://www.paraesthesia.com/archive/2011/05/02/when-staticfilehandler-is-not-staticfilehandler.aspx/).
+
+
+## Using ImageProcessor
+Support for remote files has been added to ImageProcessor in version > `2.3.2`. You'll also want to ensure that you are using Virtual Path Provider as ImageProcessor only hijacks requests when parameters are present in the querystring (like width, height, etc).
 
 ```powershell
 Install-Package ImageProcessor.Web.Config

--- a/README.md
+++ b/README.md
@@ -28,26 +28,11 @@ Add the following keys to `~/Web.config`
 ```
 `Region`, `BucketPrefix`, and `BucketName` are always required.
 
-If `DisableVirtualPathProvider` is set to `true`, you must include `BucketHostname`. However, if `DisableVirtualPathProvider` is set to `false` then `BucketHostname` doesn't have any effect.
+`DisableVirtualPathProvider` can be left empty as it will default to `false`.
 
-`DisableVirtualPathProvider` defaults to `false`.
+If `DisableVirtualPathProvider` is set to `true`, you must include `BucketHostname`. However, if `DisableVirtualPathProvider` is set to `false` then `BucketHostname` can be left empty, as it doesn't have any effect.
 
-Ok so where are the [IAM access keys?](http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html) Depending on how you host your project they already exist if deploying inside an EC2 instance via environment variables specified during deployment and creation of infrastructure.
-It's also a good idea to use [AWS best security practices](http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html). Like not using your root access account, use short lived access keys and don't EVER commit them to source control.
-
-If you aren't using EC2/ElasticBeanstalk to access generated temporary keys, you can put them into `~/Web.config`
-```xml
-<?xml version="1.0"?>
-<configuration>
-  <appSettings>
-    <add key="AWSAccessKey" value="" />
-    <add key="AWSSecretKey" value="" />
-  </appSettings>
-</configuration>
-```
-
-
-If you have left `DisableVirtualPathProvider` as the default, then you'll need to add the following to `~/Web.config`
+If `DisableVirtualPathProvider` is set to `default` or left empty, then you'll need to add the following to `~/Web.config`
 ```xml
 <?xml version="1.0"?>
 <configuration>
@@ -74,6 +59,24 @@ You also need to add the following to `~/Media/Web.config`
   </system.webServer>
 </configuration>
 ```
+
+
+## AWS Authentication
+
+Ok so where are the [IAM access keys?](http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html) Depending on how you host your project they already exist if deploying inside an EC2 instance via environment variables specified during deployment and creation of infrastructure.
+It's also a good idea to use [AWS best security practices](http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html). Like not using your root access account, use short lived access keys and don't EVER commit them to source control.
+
+If you aren't using EC2/ElasticBeanstalk to access generated temporary keys, you can put them into `~/Web.config`
+```xml
+<?xml version="1.0"?>
+<configuration>
+  <appSettings>
+    <add key="AWSAccessKey" value="" />
+    <add key="AWSSecretKey" value="" />
+  </appSettings>
+</configuration>
+```
+
 
 ## Should I use the Virtual Path Provider?
 Using a custom [Virtual Path Provider](https://msdn.microsoft.com/en-us/library/system.web.hosting.virtualpathprovider%28v=vs.110%29.aspx) (the default configuration) means your files are routed transparently through your domain (e.g. `https://example.com/media`). Anyone visiting your site won't be able to tell your files are stored on S3.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,16 @@ Add the following keys to `~/Web.config`
   </appSettings>
 </configuration>
 ```
-`Region`, `BucketPrefix`, and `BucketName` are always required.
 
-`DisableVirtualPathProvider` can be left empty as it will default to `false`.
+| Key | Required | Default | Description
+| --- | --- | --- | --- |
+| `Region` | Yes | N/A | The code for the region your S3 bucket is located in, e.g. `eu-west-2` |
+| `BucketPrefix` | Yes | N/A | The prefix for any files/directories being added to S3. Essentially a root directory name. |
+| `BucketName` | Yes | N/A | The name of your S3 bucket. |
+| `BucketHostname` | Sometimes | N/A | The hostname for your bucket (e.g. `test-s3-bucket.s3.eu-west-2.amazonaws.com`). Required when `DisableVirtualPathProvider` is set to `true` |
+| `DisableVirtualPathProvider` | No | `false` | Setting this to `true` will disable the VPP functionality. See below for more info. |
 
-If `DisableVirtualPathProvider` is set to `true`, you must include `BucketHostname`. However, if `DisableVirtualPathProvider` is set to `false` then `BucketHostname` can be left empty, as it doesn't have any effect.
-
-If `DisableVirtualPathProvider` is set to `default` or left empty, then you'll need to add the following to `~/Web.config`
+If `DisableVirtualPathProvider` is set to `false` or left empty, then you'll need to add the following to `~/Web.config`
 ```xml
 <?xml version="1.0"?>
 <configuration>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Add the following keys to `~/Web.config`
 </configuration>
 ```
 `Region`, `BucketPrefix`, and `BucketName` are always required.
+
 If `DisableVirtualPathProvider` is set to `true`, you must include `BucketHostname`. However, if `DisableVirtualPathProvider` is set to `false` then `BucketHostname` doesn't have any effect.
+
 `DisableVirtualPathProvider` defaults to `false`.
 
 Ok so where are the [IAM access keys?](http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html) Depending on how you host your project they already exist if deploying inside an EC2 instance via environment variables specified during deployment and creation of infrastructure.
@@ -43,6 +45,7 @@ If you aren't using EC2/ElasticBeanstalk to access generated temporary keys, you
   </appSettings>
 </configuration>
 ```
+
 
 If you have left `DisableVirtualPathProvider` as the default, then you'll need to add the following to `~/Web.config`
 ```xml

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Storage.S3.Tests
     {
         private BucketFileSystem CreateProvider(Mock<IAmazonS3> mock)
         {
-            return CreateProviderWithParams(mock, "test", "http://test.amazonaws.com", "media", string.Empty);
+            return CreateProviderWithParams(mock, "test", "test.amazonaws.com", "media", string.Empty);
         }
 
         private BucketFileSystem CreateProviderWithParams(
@@ -164,7 +164,7 @@ namespace Umbraco.Storage.S3.Tests
             clientMock.Setup(p => p.PutObject(It.Is<PutObjectRequest>(req => req.Key == "media/1001/media.jpg")))
                       .Returns(new PutObjectResponse());
 
-            var provider = CreateProviderWithParams(clientMock, "test", null, "media", string.Empty, "private");
+            var provider = CreateProviderWithParams(clientMock, "test", string.Empty, "media", string.Empty, "private");
 
             //Act
             provider.AddFile("/media/1001/media.jpg", stream);
@@ -182,7 +182,7 @@ namespace Umbraco.Storage.S3.Tests
             clientMock.Setup(p => p.PutObject(It.Is<PutObjectRequest>(req => req.Key == "media/1001/media.jpg")))
                       .Returns(new PutObjectResponse());
 
-            var provider = CreateProviderWithParams(clientMock, "test", null, "media", string.Empty, null, "AES256");
+            var provider = CreateProviderWithParams(clientMock, "test", string.Empty, "media", string.Empty, null, "AES256");
 
             //Act
             provider.AddFile("/media/1001/media.jpg", stream);
@@ -515,7 +515,7 @@ namespace Umbraco.Storage.S3.Tests
             //Arrange
             var clientMock = new Mock<IAmazonS3>();
             clientMock.Setup(p => p.GetObjectMetadata(It.Is<GetObjectMetadataRequest>(req => req.Key == "media/1001/media.jpg")))
-                      .Throws(new AmazonS3Exception("media/1001/media.jpg", ErrorType.Sender, "404 Not Found", "", HttpStatusCode.NotFound));
+                      .Throws(new AmazonS3Exception("media/1001/media.jpg", ErrorType.Sender, "404 Not Found", string.Empty, HttpStatusCode.NotFound));
 
             var provider = CreateProvider(clientMock);
 
@@ -550,7 +550,7 @@ namespace Umbraco.Storage.S3.Tests
             var actual = provider.GetUrl("1001/media.jpg");
 
             //Assert
-            Assert.AreEqual("http://test.amazonaws.com/media/1001/media.jpg", actual);
+            Assert.AreEqual("https://test.amazonaws.com/media/1001/media.jpg", actual);
         }
 
         [Test]
@@ -573,7 +573,20 @@ namespace Umbraco.Storage.S3.Tests
             var provider = CreateProvider(null);
 
             //Act
-            var actual = provider.GetRelativePath("http://test.amazonaws.com/media/1001/media.jpg");
+            var actual = provider.GetRelativePath("https://test.amazonaws.com/media/1001/media.jpg");
+
+            //Assert
+            Assert.AreEqual("1001/media.jpg", actual);
+        }
+
+        [Test]
+        public void ResolveRelativePathPrefixNoProtocol()
+        {
+            //Arrange
+            var provider = CreateProvider(null);
+
+            //Act
+            var actual = provider.GetRelativePath("test.amazonaws.com/media/1001/media.jpg");
 
             //Assert
             Assert.AreEqual("1001/media.jpg", actual);

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
@@ -28,7 +28,8 @@ namespace Umbraco.Storage.S3.Tests
             string bucketKeyPrefix,
             string region,
             string cannedACL = null,
-            string serverSideEncryptionMethod = null)
+            string serverSideEncryptionMethod = null,
+            bool disableVirtualPathProvider = true)
         {
             var logHelperMock = new Mock<ILogger>();
             var mimeTypeResolver = new Mock<IMimeTypeResolver>();
@@ -39,9 +40,10 @@ namespace Umbraco.Storage.S3.Tests
                 BucketPrefix = bucketKeyPrefix,
                 Region = region,
                 CannedACL = cannedACL,
-                ServerSideEncryptionMethod = serverSideEncryptionMethod
+                ServerSideEncryptionMethod = serverSideEncryptionMethod,
+                DisableVirtualPathProvider = disableVirtualPathProvider
             };
-            return new BucketFileSystem(config, mimeTypeResolver.Object, null, logHelperMock.Object);
+            return new BucketFileSystem(config, mimeTypeResolver.Object, null, logHelperMock.Object, mock?.Object);
         }
 
         [Test]

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemAbsoluteTests.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Storage.S3.Tests
                 CannedACL = cannedACL,
                 ServerSideEncryptionMethod = serverSideEncryptionMethod
             };
-            return new BucketFileSystem(config, mimeTypeResolver.Object, null, mock.Object, logHelperMock.Object);
+            return new BucketFileSystem(config, mimeTypeResolver.Object, null, logHelperMock.Object);
         }
 
         [Test]

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemRelativeTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemRelativeTests.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Storage.S3.Tests
                 BucketName = "test",
                 BucketPrefix = "media"
             };
-            return new BucketFileSystem(config, mimeTypeResolverMock.Object, null, mock.Object, loggerMock.Object);
+            return new BucketFileSystem(config, mimeTypeResolverMock.Object, null, loggerMock.Object);
         }
 
         [Test]

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemRelativeTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemRelativeTests.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Storage.S3.Tests
                 BucketName = "test",
                 BucketPrefix = "media"
             };
-            return new BucketFileSystem(config, mimeTypeResolverMock.Object, null, loggerMock.Object);
+            return new BucketFileSystem(config, mimeTypeResolverMock.Object, null, loggerMock.Object, mock?.Object);
         }
 
         [Test]

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemRelativeTests.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/BucketFileSystemRelativeTests.cs
@@ -16,7 +16,10 @@ namespace Umbraco.Storage.S3.Tests
             var config = new BucketFileSystemConfig()
             {
                 BucketName = "test",
-                BucketPrefix = "media"
+                BucketHostName = string.Empty,
+                BucketPrefix = "media",
+                Region = string.Empty,
+                DisableVirtualPathProvider = false
             };
             return new BucketFileSystem(config, mimeTypeResolverMock.Object, null, loggerMock.Object, mock?.Object);
         }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/Umbraco.Storage.S3.Tests.csproj
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/Umbraco.Storage.S3.Tests.csproj
@@ -46,10 +46,10 @@
       <HintPath>..\packages\AutoMapper.8.0.0\lib\net461\AutoMapper.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.Core.3.3.31.12\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.Core.3.3.103.29\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.S3.3.3.31.20\lib\net45\AWSSDK.S3.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.S3.3.3.104.17\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
@@ -118,8 +118,14 @@
     <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog.Sinks.Async, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Async.1.3.0\lib\net45\Serilog.Sinks.Async.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Map, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Map.1.0.0\lib\netstandard2.0\Serilog.Sinks.Map.dll</HintPath>
     </Reference>
     <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
@@ -162,7 +168,7 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.8.1.3\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -196,7 +202,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\AWSSDK.S3.3.3.31.20\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\AWSSDK.S3.3.3.104.17\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/Umbraco.Storage.S3.Tests.csproj
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/Umbraco.Storage.S3.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -225,6 +226,7 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
     <Error Condition="!Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/packages.config
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/packages.config
@@ -17,6 +17,7 @@
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
   <package id="NPoco" version="3.9.4" targetFramework="net472" />
   <package id="NUnit" version="3.11.0" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="3.14.0" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="Semver" version="2.0.4" targetFramework="net472" />
   <package id="Serilog" version="2.8.0" targetFramework="net472" />

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/packages.config
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="8.0.0" targetFramework="net472" />
-  <package id="AWSSDK.Core" version="3.3.31.12" targetFramework="net472" />
-  <package id="AWSSDK.S3" version="3.3.31.20" targetFramework="net472" />
+  <package id="AWSSDK.Core" version="3.3.103.29" targetFramework="net472" />
+  <package id="AWSSDK.S3" version="3.3.104.17" targetFramework="net472" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net472" />
   <package id="LightInject" version="5.4.0" targetFramework="net472" />
   <package id="LightInject.Annotation" version="1.1.0" targetFramework="net472" />
@@ -27,12 +27,14 @@
   <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net472" />
   <package id="Serilog.Formatting.Compact.Reader" version="1.0.3" targetFramework="net472" />
   <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net472" />
+  <package id="Serilog.Sinks.Async" version="1.3.0" targetFramework="net472" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Map" version="1.0.0" targetFramework="net472" />
   <package id="Superpower" version="2.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
-  <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.1.3" targetFramework="net472" />
 </packages>

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
@@ -328,7 +328,21 @@ namespace Umbraco.Storage.S3
 
         public virtual string GetUrl(string path)
         {
-            return string.Concat(Config.BucketHostName, "/", ResolveBucketPath(path));
+            var hostName = Config.BucketHostName;
+
+            if (Config.DisableVirtualPathProvider) {
+                var protocol = hostName.Substring(0, 7).ToLower();
+                if (protocol != "https:/" && protocol != "http://")
+                {
+                    hostName = "https://" + hostName;
+                }
+            }
+            else
+            {
+                hostName = "";
+            }
+
+            return string.Concat(hostName, "/", ResolveBucketPath(path));
         }
 
         public virtual DateTimeOffset GetLastModified(string path)

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystem.cs
@@ -28,14 +28,14 @@ namespace Umbraco.Storage.S3
             BucketFileSystemConfig config,
             IMimeTypeResolver mimeTypeResolver,
             IFileCacheProvider fileCacheProvider,
-            ILogger logger)
+            ILogger logger,
+            IAmazonS3 s3Client)
         {
             Config = config;
             FileCacheProvider = fileCacheProvider;
             MimeTypeResolver = mimeTypeResolver;
             Logger = logger;
-            S3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(config.Region));
-
+            S3Client = s3Client;
         }
 
         public bool CanAddPhysical => false;

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComponent.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComponent.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Storage.S3
         public void Initialize()
         {
             var fs = this.supportingFileSystems.For<IMediaFileSystem>() as BucketFileSystem;
-            if (fs != null)
+            if (!this.config.DisableVirtualPathProvider && fs != null)
             {
                 FileSystemVirtualPathProvider.ConfigureMedia();
             }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComponent.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComponent.cs
@@ -1,17 +1,31 @@
 ﻿using Umbraco.Core.Composing;
+using Umbraco.Core.IO;
 
 namespace Umbraco.Storage.S3
 {
-    public class S3FileSystemComponent : IComponent
+    public class BucketFileSystemComponent : IComponent
     {
+        private readonly SupportingFileSystems supportingFileSystems;
+        private readonly BucketFileSystemConfig config;
+
+        public BucketFileSystemComponent(SupportingFileSystems supportingFileSystems, BucketFileSystemConfig config)
+        {
+            this.supportingFileSystems = supportingFileSystems;
+            this.config = config;
+        }
+
         public void Initialize()
         {
-            throw new System.NotImplementedException();
+            var fs = this.supportingFileSystems.For<IMediaFileSystem>() as BucketFileSystem;
+            if (fs != null)
+            {
+                FileSystemVirtualPathProvider.ConfigureMedia();
+            }
         }
 
         public void Terminate()
         {
-            throw new System.NotImplementedException();
+
         }
     }
 }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
@@ -1,14 +1,52 @@
-﻿using Umbraco.Core;
+﻿using Amazon.S3;
+using System.Configuration;
+using Umbraco.Core;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Logging;
+using Umbraco.Storage.S3.Services;
 
 namespace Umbraco.Storage.S3
 {
     [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
     public class BucketFileSystemComposer : IComposer
     {
+        private const string AppSettingsKey = "BucketFileSystem";
+        private const string ProviderAlias = "media";
         public void Compose(Composition composition)
         {
- 
+
+            var bucketName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketName"];
+            if (bucketName != null)
+            {
+                var config = CreateConfiguration();
+
+                composition.RegisterUnique(config);
+                composition.Register<IMimeTypeResolver>(new DefaultMimeTypeResolver());
+
+                composition.SetMediaFileSystem((f) => new BucketFileSystem(config, f.GetInstance<IMimeTypeResolver>(), null, f.GetInstance<ILogger>())); ;
+
+                composition.Components().Append<BucketFileSystemComponent>();
+
+            }
+
+        }
+
+        private BucketFileSystemConfig CreateConfiguration()
+        {
+            var bucketName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketName"];
+            var bucketHostName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketHostname"];
+            var bucketPrefix = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketPrefix"];
+            var region = ConfigurationManager.AppSettings[$"{AppSettingsKey}:Region"];
+
+            return new BucketFileSystemConfig
+            {
+                BucketName = bucketName,
+                BucketHostName = bucketHostName,
+                BucketPrefix = bucketPrefix,
+                Region = region,
+                CannedACL = new Amazon.S3.S3CannedACL("public-read"),
+                ServerSideEncryptionMethod = ""
+            };
         }
     }
 }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
@@ -2,6 +2,7 @@
 using System.Configuration;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Exceptions;
 using Umbraco.Core.Logging;
 using Umbraco.Storage.S3.Services;
 
@@ -37,6 +38,19 @@ namespace Umbraco.Storage.S3
             var bucketHostName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketHostname"];
             var bucketPrefix = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketPrefix"];
             var region = ConfigurationManager.AppSettings[$"{AppSettingsKey}:Region"];
+            bool.TryParse(ConfigurationManager.AppSettings[$"{AppSettingsKey}:DisableVirtualPathProvider"], out var disableVirtualPathProvider);
+
+            if (string.IsNullOrEmpty(bucketName))
+                throw new ArgumentNullOrEmptyException("BucketName", $"The AWS S3 Bucket File System is missing the value '{AppSettingsKey}:BucketName' from AppSettings");
+
+            if (string.IsNullOrEmpty(bucketPrefix))
+                throw new ArgumentNullOrEmptyException("BucketPrefix", $"The AWS S3 Bucket File System is missing the value '{AppSettingsKey}:BucketPrefix' from AppSettings");
+
+            if (string.IsNullOrEmpty(region))
+                throw new ArgumentNullOrEmptyException("Region", $"The AWS S3 Bucket File System is missing the value '{AppSettingsKey}:Region' from AppSettings");
+
+            if (disableVirtualPathProvider && string.IsNullOrEmpty(bucketHostName))
+                throw new ArgumentNullOrEmptyException("BucketHostname", $"The AWS S3 Bucket File System is missing the value '{AppSettingsKey}:BucketHostname' from AppSettings");
 
             return new BucketFileSystemConfig
             {
@@ -45,7 +59,8 @@ namespace Umbraco.Storage.S3
                 BucketPrefix = bucketPrefix,
                 Region = region,
                 CannedACL = new Amazon.S3.S3CannedACL("public-read"),
-                ServerSideEncryptionMethod = ""
+                ServerSideEncryptionMethod = "",
+                DisableVirtualPathProvider = disableVirtualPathProvider
             };
         }
     }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
@@ -13,6 +13,8 @@ namespace Umbraco.Storage.S3
     {
         private const string AppSettingsKey = "BucketFileSystem";
         private const string ProviderAlias = "media";
+        private readonly char[] Delimiters = "/".ToCharArray();
+
         public void Compose(Composition composition)
         {
 
@@ -42,7 +44,7 @@ namespace Umbraco.Storage.S3
         {
             var bucketName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketName"];
             var bucketHostName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketHostname"];
-            var bucketPrefix = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketPrefix"];
+            var bucketPrefix = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketPrefix"].TrimStart(Delimiters).TrimEnd(Delimiters);
             var region = ConfigurationManager.AppSettings[$"{AppSettingsKey}:Region"];
             bool.TryParse(ConfigurationManager.AppSettings[$"{AppSettingsKey}:DisableVirtualPathProvider"], out var disableVirtualPathProvider);
 

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemComposer.cs
@@ -24,7 +24,13 @@ namespace Umbraco.Storage.S3
                 composition.RegisterUnique(config);
                 composition.Register<IMimeTypeResolver>(new DefaultMimeTypeResolver());
 
-                composition.SetMediaFileSystem((f) => new BucketFileSystem(config, f.GetInstance<IMimeTypeResolver>(), null, f.GetInstance<ILogger>())); ;
+                composition.SetMediaFileSystem((f) => new BucketFileSystem(
+                    config,
+                    f.GetInstance<IMimeTypeResolver>(),
+                    null,
+                    f.GetInstance<ILogger>(),
+                    new AmazonS3Client(Amazon.RegionEndpoint.GetBySystemName(config.Region))
+                ));
 
                 composition.Components().Append<BucketFileSystemComponent>();
 

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemConfig.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemConfig.cs
@@ -15,5 +15,7 @@ namespace Umbraco.Storage.S3
         public S3CannedACL CannedACL { get; set; }
 
         public ServerSideEncryptionMethod ServerSideEncryptionMethod { get; set; }
+
+        public bool DisableVirtualPathProvider { get; set; }
     }
 }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/Umbraco.Storage.S3.csproj
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/Umbraco.Storage.S3.csproj
@@ -47,6 +47,7 @@
       <HintPath>..\packages\AWSSDK.S3.3.3.31.20\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="Umbraco.Core">

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/Umbraco.Storage.S3.csproj
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/Umbraco.Storage.S3.csproj
@@ -41,17 +41,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.Core.3.3.31.12\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.Core.3.3.103.29\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.S3.3.3.31.20\lib\net45\AWSSDK.S3.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.S3.3.3.104.17\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="Umbraco.Core">
-      <HintPath>..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
+    <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.8.1.3\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -79,7 +79,7 @@
     <None Include="Umbraco.Storage.S3.nuspec" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\AWSSDK.S3.3.3.31.20\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\AWSSDK.S3.3.3.104.17\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/packages.config
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.31.12" targetFramework="net45" />
-  <package id="AWSSDK.S3" version="3.3.31.20" targetFramework="net45" />
-  <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="AWSSDK.Core" version="3.3.103.29" targetFramework="net472" />
+  <package id="AWSSDK.S3" version="3.3.104.17" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.1.3" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Solves #34 

@neilgaietto made a great start on this but still had some issues, so I've solved the issues mentioned (here)[https://github.com/ElijahGlover/Umbraco-S3-Provider/issues/34#issuecomment-518881975].

I've added a Web.config setting to make it easy to choose between using the VPP or just the raw S3 URLs. I've also made the code dealing with the hostname a bit more flexible (you don't _have_ to include `http(s)://` anymore. This was mainly to solve the first issue from Neil.

Prefixes can have any number of slashes in them. Leading and trailing slashes are also handled without creating directories with no name.

I've updated the readme to reflect the changes in config, etc. I've tried to leave as much of the original info as possible while taking out anything out of date.